### PR TITLE
docs(readme): include hiring tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## 👩‍💻 Hiring 👨‍💻
 
 Want to get paid for your contributions to `react-seo`?
-> SEO tag manager for React
+> Send your resume to oneamex.careers@aexp.com
 
 ## 📖 Table of Contents
 


### PR DESCRIPTION
Replaces the hiring tag line that was lost on a bad rebase.