### PR TITLE
fix(title): do not override browser tab title

### DIFF
--- a/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/__tests__/__snapshots__/index.spec.jsx.snap
@@ -48,8 +48,6 @@ exports[`SEO should render articles correctly 1`] = `
       },
     ]
   }
-  title="Lorem Ipsum"
-  titleTemplate=""
 />
 `;
 
@@ -108,8 +106,6 @@ exports[`SEO should render children correctly 1`] = `
       },
     ]
   }
-  title="Lorem Ipsum"
-  titleTemplate=""
 >
   <script
     src="https://example.com/foo.js"
@@ -177,8 +173,6 @@ exports[`SEO should render images correctly 1`] = `
       },
     ]
   }
-  title="Lorem Ipsum"
-  titleTemplate=""
 />
 `;
 
@@ -237,8 +231,6 @@ exports[`SEO should render images pathnames correctly 1`] = `
       },
     ]
   }
-  title="Lorem Ipsum"
-  titleTemplate=""
 />
 `;
 
@@ -290,7 +282,5 @@ exports[`SEO should render the snapshot correctly 1`] = `
       },
     ]
   }
-  title="Lorem Ipsum"
-  titleTemplate=""
 />
 `;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -28,7 +28,6 @@ const SEO = ({
   pathname,
   siteUrl,
   title,
-  titleTemplate,
 }) => {
   const image = metaImage && metaImage.src ? `${siteUrl}${metaImage.src}` : null;
 
@@ -105,10 +104,8 @@ const SEO = ({
   return (
     <Helmet
       htmlAttributes={{ lang }}
-      title={title}
       link={link}
       meta={metaTags}
-      titleTemplate={titleTemplate}
     >
       {children}
     </Helmet>
@@ -129,7 +126,6 @@ SEO.propTypes = {
   pathname: PropTypes.string,
   siteUrl: PropTypes.string,
   title: PropTypes.string,
-  titleTemplate: PropTypes.string,
 };
 
 SEO.defaultProps = {
@@ -144,7 +140,6 @@ SEO.defaultProps = {
   pathname: '',
   siteUrl: '',
   title: '',
-  titleTemplate: '',
 };
 
 export default SEO;


### PR DESCRIPTION
Setting `og:title` should not override the browser's title tab