### PR TITLE
feat(seo): add robots support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const MyModule = () => (
     <SEO
       title="Lorem Ipsum"
       description="Lorem ipsum sat delor."
+      robots={['index', 'follow']}
       keywords={['foo', 'bar']}
       siteUrl="http://example.com"
       openGraph={{
@@ -201,6 +202,7 @@ SEO.propTypes = {
     }),
   }),
   keywords: arrayOf(string),
+  robots: arrayOf(string),
   locale: string,
   meta: arrayOf(object),
   siteUrl: string,
@@ -212,6 +214,7 @@ SEO.defaultProps = {
   description: '',
   image: null,
   keywords: [],
+  robots: [],
   locale: 'en-US',
   meta: [],
   pathname: '',

--- a/__tests__/components/SEO.spec.jsx
+++ b/__tests__/components/SEO.spec.jsx
@@ -48,6 +48,28 @@ describe('SEO', () => {
     }]);
   });
 
+  it('should provide the robots', () => {
+    const component = shallow(
+      <SEO
+        description="Lorem ipsum sat delor."
+        keywords={['foo', 'bar']}
+        robots={['index', 'follow']}
+        siteUrl="https://example.com"
+        title="Lorem Ipsum"
+        canonical="https://example.com/index.html"
+      />
+    );
+
+    const helmet = component.find('Helmet');
+    const { meta } = helmet.props();
+
+    const robots = meta.find((tag) => tag.name === 'robots');
+
+    expect(robots).toMatchObject({
+      name: 'robots', content: 'index,follow',
+    });
+  });
+
   it('should render image tags correctly', () => {
     const component = shallow(
       <SEO

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -26,6 +26,7 @@ const SEO = ({
   titleTemplate,
   canonical,
   keywords,
+  robots,
   openGraph,
   twitterCard,
   image,
@@ -66,6 +67,10 @@ const SEO = ({
     meta.push({ name: 'keywords', content: keywords.join(',') });
   }
 
+  if (robots.length > 0) {
+    meta.push({ name: 'robots', content: robots.join(',') });
+  }
+
   return (
     <Helmet
       htmlAttributes={{
@@ -90,6 +95,7 @@ SEO.propTypes = {
   openGraph: openGraphShape,
   twitterCard: twitterCardShape,
   keywords: PropTypes.arrayOf(PropTypes.string),
+  robots: PropTypes.arrayOf(PropTypes.string),
   image: PropTypes.shape({
     url: PropTypes.string,
     secureUrl: PropTypes.string,
@@ -114,6 +120,7 @@ SEO.defaultProps = {
   titleTemplate: '',
   canonical: '',
   keywords: [],
+  robots: [],
   image: undefined,
   video: undefined,
   openGraph: undefined,


### PR DESCRIPTION
This change adds support for the robots meta tag by allowing robots directives to be passed as an array of strings.