### PR TITLE
fix(getTwitterCardTags): summary_large_image twitter card type

### DIFF
--- a/__tests__/utils/getTwitterCardTags.spec.js
+++ b/__tests__/utils/getTwitterCardTags.spec.js
@@ -14,6 +14,10 @@
 
 import getTwitterCardTags from '../../src/utils/getTwitterCardTags';
 
+global.console = {
+  warn: jest.fn(),
+};
+
 describe('getTwitterCardTags', () => {
   describe('summary card', () => {
     it('should provide the tags for a summary card', () => {
@@ -37,6 +41,56 @@ describe('getTwitterCardTags', () => {
         { name: 'twitter:image', content: 'http://example.com/ogp.jpg' },
         { name: 'twitter:image:alt', content: 'A shiny red apple with a bite taken out' },
       ]);
+    });
+  });
+
+  describe('summary with large image card', () => {
+    it('should provide the tags for a summary with large image card', () => {
+      const config = {
+        card: 'summary_large_image',
+        site: '@Example',
+        title: 'Some title',
+        description: 'Some description',
+        image: {
+          src: 'http://example.com/ogp.jpg',
+          alt: 'A shiny red apple with a bite taken out',
+        },
+        irrelevantProperty: 'foo',
+      };
+
+      expect(getTwitterCardTags(config)).toEqual([
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:site', content: '@Example' },
+        { name: 'twitter:title', content: 'Some title' },
+        { name: 'twitter:description', content: 'Some description' },
+        { name: 'twitter:image', content: 'http://example.com/ogp.jpg' },
+        { name: 'twitter:image:alt', content: 'A shiny red apple with a bite taken out' },
+      ]);
+    });
+
+    it('should warn about deprecation of summary_with_large_image', () => {
+      const config = {
+        card: 'summary_with_large_image',
+        site: '@Example',
+        title: 'Some title',
+        description: 'Some description',
+        image: {
+          src: 'http://example.com/ogp.jpg',
+          alt: 'A shiny red apple with a bite taken out',
+        },
+        irrelevantProperty: 'foo',
+      };
+
+      expect(getTwitterCardTags(config)).toEqual([
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:site', content: '@Example' },
+        { name: 'twitter:title', content: 'Some title' },
+        { name: 'twitter:description', content: 'Some description' },
+        { name: 'twitter:image', content: 'http://example.com/ogp.jpg' },
+        { name: 'twitter:image:alt', content: 'A shiny red apple with a bite taken out' },
+      ]);
+
+      expect(global.console.warn).toHaveBeenCalled();
     });
   });
 

--- a/src/utils/getTwitterCardTags.js
+++ b/src/utils/getTwitterCardTags.js
@@ -23,10 +23,22 @@ const schemas = {
   player: TWITTER_PLAYER_CARD_SCHEMA,
   app: TWITTER_APP_CARD_SCHEMA,
   summary: TWITTER_SUMMARY_CARD_SCHEMA,
-  summary_with_large_image: TWITTER_SUMMARY_CARD_SCHEMA,
+  summary_large_image: TWITTER_SUMMARY_CARD_SCHEMA,
 };
 
 const getTwitterCardTags = (tags) => {
+  if (tags.card === 'summary_with_large_image') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'summary_with_large_image is deprecated and will be removed in the next major release. Please use summary_large_image instead. See https://github.com/americanexpress/react-seo/issues/24 for more information'
+    );
+
+    return getTagsFromSchema(schemas.summary_large_image, {
+      ...tags,
+      card: 'summary_large_image',
+    });
+  }
+
   if (schemas[tags.card]) {
     return getTagsFromSchema(schemas[tags.card], tags);
   }


### PR DESCRIPTION
This change fixes support for summary_large_image Twitter Card type
which was incorrectly defined as summary_with_large_image.

Closes #24