### PR TITLE
chore(release): configure semantic-release for branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,20 @@
     "react-helmet": "^6.1.0"
   },
   "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "main",
+      "next",
+      "next-major",
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
@@ -77,8 +91,7 @@
       "@semantic-release/npm",
       "@semantic-release/git",
       "@semantic-release/github"
-    ],
-    "branch": "main"
+    ]
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This configures semantic-release to cut releases from the main, next, and support branches as well as cutting alpha and beta prereleases.